### PR TITLE
Fix repo name in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ An automatic lid switch handler for Hyprland that intelligently manages monitor 
 ### Quick Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/aserper/hyprland-lid-switch/main/install-hyprland-lid-switch.sh | bash
+curl -fsSL https://raw.githubusercontent.com/aserper/arch-lidswitch/main/install-hyprland-lid-switch.sh | bash
 ```
 
 ### Manual Install
 
 1. **Download the installer**:
    ```bash
-   wget https://raw.githubusercontent.com/aserper/hyprland-lid-switch/main/install-hyprland-lid-switch.sh
+   wget https://raw.githubusercontent.com/aserper/arch-lidswitch/main/install-hyprland-lid-switch.sh
    chmod +x install-hyprland-lid-switch.sh
    ```
 


### PR DESCRIPTION
Hey, I just installed your script and I noticed that the install instructions point to the wrong repository, which led to 404 errors on curl (and I assume also  on wget).

Aside from that - works great! Thank you.